### PR TITLE
:green_heart: notification ci result to slack

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -105,3 +105,17 @@ jobs:
 
       - name: Build release
         run: cargo build --release --verbose
+
+  slack_notify:
+    name: Slack Notification
+    needs: [test, build]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_TITLE: Rust CI
+          SLACK_COLOR: ${{ job.status }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_USERNAME: konkon


### PR DESCRIPTION
## Sourcery によるサマリー

CI:
- Rust CI ワークフローの完了時に、ジョブのステータスに関わらず Slack 通知を送信するようにしました。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Send a Slack notification on the Rust CI workflow completion, regardless of the job status.

</details>