### PR TITLE
:tada:  usecase for handle redirect

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,8 +23,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
+  lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -54,22 +54,92 @@ jobs:
         uses: actions/cache@v3
         with:
           path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-lint-target-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-build-target-
+            ${{ runner.os }}-cargo-lint-target-
 
-    #   - name: Check formatting
-    #     run: cargo fmt --all -- --check
+      # - name: Check formatting
+      #   run: cargo fmt --all -- --check
 
       - name: Clippy
         run: cargo clippy -- -D warnings
 
-      - name: Run tests
-        run: cargo test --verbose
+  unit_test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
+
+      - name: Cache cargo target
+        uses: actions/cache@v3
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-unit-test-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-unit-test-target-
+
+      - name: Run unit tests
+        run: cargo test --lib --bins --verbose
+
+  integration_test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-registry-
+
+      - name: Cache cargo index
+        uses: actions/cache@v3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-index-
+
+      - name: Cache cargo target
+        uses: actions/cache@v3
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-integration-test-target-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-integration-test-target-
+
+      - name: Run integration tests
+        run: cargo test --test '*' --verbose
 
   build:
     name: Build
     runs-on: ubuntu-latest
+    needs: [lint, unit_test, integration_test]
     steps:
       - uses: actions/checkout@v4
 
@@ -108,7 +178,7 @@ jobs:
 
   slack_notify:
     name: Slack Notification
-    needs: [test, build]
+    needs: [lint, unit_test, integration_test, build]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 target/
 .env
+.clinerules

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clippy audit audit-fix test-integration
+.PHONY: clippy audit audit-fix test-unit test-integration
 
 audit:
 	cargo audit
@@ -8,6 +8,9 @@ audit-fix:
 
 clippy:
 	cargo clippy -- -D warnings
+
+test-unit:
+	cargo test --lib
 
 test-integration:
 	cargo test --test integration_tests

--- a/src/adapter/outbound/okka_adapter.rs
+++ b/src/adapter/outbound/okka_adapter.rs
@@ -30,6 +30,7 @@ type OAuthClient = OriginalClient<
 pub struct OkkaOAuthProvider {
   client: OAuthClient,
   http_client: Client,
+  issuer: String,
 }
 
 impl OkkaOAuthProvider {
@@ -39,6 +40,7 @@ impl OkkaOAuthProvider {
     client_id: &str,
     client_secret: Option<&str>,
     redirect_url: &str,
+    issuer: &str,
   ) -> Result<Self, AuthError> {
     let client = BasicClient::new(ClientId::new(client_id.to_string()))
       .set_redirect_uri(
@@ -58,7 +60,11 @@ impl OkkaOAuthProvider {
       .build()
       .map_err(|e| AuthError::ConfigurationError(e.to_string()))?;
 
-    Ok(Self { client, http_client })
+    Ok(Self {
+      client,
+      http_client,
+      issuer: issuer.to_string(),
+    })
   }
 }
 
@@ -130,6 +136,9 @@ impl OAuthProvider for OkkaOAuthProvider {
       authorization_endpoint: self.client.auth_uri().as_str().to_string(),
       token_endpoint: self.client.token_uri().as_str().to_string(),
       revocation_endpoint: None,
+      client_id: self.client.client_id().to_string(),
+      redirect_uri: self.client.redirect_uri().map(|r| r.as_str().to_string()).unwrap_or_default(),
+      issuer: self.issuer.clone(),
     })
   }
 }

--- a/src/config/envs.rs
+++ b/src/config/envs.rs
@@ -21,6 +21,7 @@ pub struct OAuthConfig {
   pub token_url: String,
   pub redirect_url: String,
   pub userinfo_url: String,
+  pub issuer: String,
 }
 
 #[derive(Clone, Debug)]
@@ -48,6 +49,7 @@ impl Config {
       token_url: env::var("OAUTH_TOKEN_URL").expect("OAUTH_TOKEN_URL must be set"),
       redirect_url: env::var("OAUTH_REDIRECT_URL").expect("OAUTH_REDIRECT_URL must be set"),
       userinfo_url: env::var("OAUTH_USERINFO_URL").expect("OAUTH_USERINFO_URL must be set"),
+      issuer: env::var("OAUTH_ISSUER").expect("OAUTH_ISSUER must be set"),
     };
 
     let redis = RedisConfig {

--- a/src/core/usecase/authentication.rs
+++ b/src/core/usecase/authentication.rs
@@ -89,16 +89,21 @@ impl<T: OAuthProvider + Clone + Send + Sync, C: CacheProvider + Clone + Send + S
     let session_key = AuthorizationConstants::pkce_session_key(&request.state);
     let pkce_session: PkceSession = self.cache_provider.get(&session_key).await?.ok_or(AuthError::InvalidState)?;
 
-    // 2. verify the session expiration
+    // 2. verify the code verifier
+    if pkce_session.code_verifier != request.code_verifier {
+      return Err(AuthError::InvalidCodeVerifier);
+    }
+
+    // 3. verify the session expiration
     let now = now_time_secs().map_err(|err| AuthError::UnexpectedError(err.to_string()))?;
     if now > pkce_session.expires_at {
       return Err(AuthError::SessionExpired);
     }
 
-    // 3. Delete the PKCE session from the cache
+    // 4. Delete the PKCE session from the cache
     let _ = self.cache_provider.remove(&session_key).await;
 
-    // 3. fetch provider config
+    // 5. fetch provider config
     let provider_config = self.oauth_provider.get_provider_config().await?;
 
     let token_request = TokenRequest {
@@ -180,12 +185,15 @@ mod tests {
   };
   use oauth2::{CsrfToken, PkceCodeVerifier};
   use serde::de::DeserializeOwned;
+  use std::collections::HashMap;
   use std::sync::{Arc, Mutex};
 
   #[derive(Clone)]
   struct MockOAuthProvider {
     generate_auth_url_result: Arc<Mutex<Result<(String, CsrfToken, PkceCodeVerifier), AuthError>>>,
     received_scopes: Arc<Mutex<Option<Vec<String>>>>,
+    get_token_result: Arc<Mutex<Result<OAuthTokenResponse, AuthError>>>,
+    provider_config: Arc<Mutex<Result<ProviderConfig, AuthError>>>,
   }
 
   #[async_trait]
@@ -204,7 +212,7 @@ mod tests {
     }
 
     async fn get_token(&self, _request: TokenRequest) -> Result<OAuthTokenResponse, AuthError> {
-      unimplemented!("Not used in this test")
+      self.get_token_result.lock().unwrap().clone()
     }
 
     async fn refresh_token(&self, _request: RefreshTokenRequest) -> Result<OAuthTokenResponse, AuthError> {
@@ -216,7 +224,7 @@ mod tests {
     }
 
     async fn get_provider_config(&self) -> Result<ProviderConfig, AuthError> {
-      unimplemented!("Not used in this test")
+      self.provider_config.lock().unwrap().clone()
     }
   }
 
@@ -224,6 +232,29 @@ mod tests {
   struct MockCacheProvider {
     store_result: Arc<Mutex<Result<(), Box<dyn std::error::Error + Send + Sync>>>>,
     store_calls: Arc<Mutex<Vec<(String, u64)>>>,
+    stored_sessions: Arc<Mutex<HashMap<String, PkceSession>>>,
+    remove_calls: Arc<Mutex<Vec<String>>>,
+  }
+
+  impl MockCacheProvider {
+    fn new() -> Self {
+      let mut sessions = HashMap::new();
+      // デフォルトのテストセッションを登録
+      sessions.insert(
+        AuthorizationConstants::pkce_session_key("test_state"),
+        PkceSession {
+          code_verifier: "test_verifier".to_string(),
+          expires_at: TEST_TIMESTAMP + AuthorizationConstants::PKCE_SESSION_TTL_SECONDS - 1,
+        },
+      );
+
+      Self {
+        store_result: Arc::new(Mutex::new(Ok(()))),
+        store_calls: Arc::new(Mutex::new(Vec::new())),
+        stored_sessions: Arc::new(Mutex::new(sessions)),
+        remove_calls: Arc::new(Mutex::new(Vec::new())),
+      }
+    }
   }
 
   #[async_trait]
@@ -231,10 +262,14 @@ mod tests {
     async fn store<T: Serialize + Send + Sync>(
       &self,
       key: &str,
-      _data: &T,
+      data: &T,
       ttl: u64,
     ) -> Result<(), Box<dyn std::error::Error>> {
       self.store_calls.lock().unwrap().push((key.to_string(), ttl));
+
+      if let Ok(session) = serde_json::from_value::<PkceSession>(serde_json::to_value(data)?) {
+        self.stored_sessions.lock().unwrap().insert(key.to_string(), session);
+      }
       let result = self.store_result.lock().unwrap();
       match *result {
         Ok(()) => Ok(()),
@@ -242,15 +277,19 @@ mod tests {
       }
     }
 
-    async fn get<T: DeserializeOwned + Send + Sync>(
-      &self,
-      _key: &str,
-    ) -> Result<Option<T>, Box<dyn std::error::Error>> {
-      unimplemented!("Not used in this test")
+    async fn get<T: DeserializeOwned + Send + Sync>(&self, key: &str) -> Result<Option<T>, Box<dyn std::error::Error>> {
+      let sessions = self.stored_sessions.lock().unwrap();
+      if let Some(session) = sessions.get(key) {
+        Ok(Some(serde_json::from_value(serde_json::to_value(session)?)?))
+      } else {
+        Ok(None)
+      }
     }
 
-    async fn remove(&self, _key: &str) -> Result<(), Box<dyn std::error::Error>> {
-      unimplemented!("Not used in this test")
+    async fn remove(&self, key: &str) -> Result<(), Box<dyn std::error::Error>> {
+      self.remove_calls.lock().unwrap().push(key.to_string());
+      self.stored_sessions.lock().unwrap().remove(key);
+      Ok(())
     }
   }
 
@@ -266,12 +305,24 @@ mod tests {
         PkceCodeVerifier::new("test_code_verifier_456".to_string()),
       )))),
       received_scopes: Arc::new(Mutex::new(None)),
+      get_token_result: Arc::new(Mutex::new(Ok(OAuthTokenResponse {
+        access_token: "test_access_token".to_string(),
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        refresh_token: Some("test_refresh_token".to_string()),
+        scope: "openid profile".to_string(),
+      }))),
+      provider_config: Arc::new(Mutex::new(Ok(ProviderConfig {
+        authorization_endpoint: "https://auth.example.com/authorize".to_string(),
+        token_endpoint: "https://auth.example.com/token".to_string(),
+        revocation_endpoint: Some("https://auth.example.com/revoke".to_string()),
+        client_id: "test_client_id".to_string(),
+        redirect_uri: "https://app.example.com/callback".to_string(),
+        issuer: "https://auth.example.com".to_string(),
+      }))),
     };
 
-    let mock_cache = MockCacheProvider {
-      store_result: Arc::new(Mutex::new(Ok(()))),
-      store_calls: Arc::new(Mutex::new(Vec::new())),
-    };
+    let mock_cache = MockCacheProvider::new();
 
     // Generate Usecase
     let use_case = AuthenticationUseCase::new(mock_oauth.clone(), mock_cache.clone());
@@ -317,13 +368,24 @@ mod tests {
         PkceCodeVerifier::new("test_code_verifier_register".to_string()),
       )))),
       received_scopes: Arc::new(Mutex::new(None)),
+      get_token_result: Arc::new(Mutex::new(Ok(OAuthTokenResponse {
+        access_token: "test_access_token".to_string(),
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        refresh_token: Some("test_refresh_token".to_string()),
+        scope: "openid profile email".to_string(),
+      }))),
+      provider_config: Arc::new(Mutex::new(Ok(ProviderConfig {
+        authorization_endpoint: "https://auth.example.com/authorize".to_string(),
+        token_endpoint: "https://auth.example.com/token".to_string(),
+        revocation_endpoint: Some("https://auth.example.com/revoke".to_string()),
+        client_id: "test_client_id".to_string(),
+        redirect_uri: "https://app.example.com/callback".to_string(),
+        issuer: "https://auth.example.com".to_string(),
+      }))),
     };
 
-    let mock_cache = MockCacheProvider {
-      store_result: Arc::new(Mutex::new(Ok(()))),
-      store_calls: Arc::new(Mutex::new(Vec::new())),
-    };
-
+    let mock_cache = MockCacheProvider::new();
     let use_case = AuthenticationUseCase::new(mock_oauth.clone(), mock_cache.clone());
 
     set_mock_time(TEST_TIMESTAMP);
@@ -355,12 +417,23 @@ mod tests {
         "Invalid OAuth configuration".to_string(),
       )))),
       received_scopes: Arc::new(Mutex::new(None)),
+      get_token_result: Arc::new(Mutex::new(Ok(OAuthTokenResponse {
+        access_token: "test_access_token".to_string(),
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        refresh_token: Some("test_refresh_token".to_string()),
+        scope: "openid profile".to_string(),
+      }))),
+      provider_config: Arc::new(Mutex::new(Ok(ProviderConfig {
+        authorization_endpoint: "https://auth.example.com/authorize".to_string(),
+        token_endpoint: "https://auth.example.com/token".to_string(),
+        revocation_endpoint: Some("https://auth.example.com/revoke".to_string()),
+        client_id: "test_client_id".to_string(),
+        redirect_uri: "https://app.example.com/callback".to_string(),
+        issuer: "https://auth.example.com".to_string(),
+      }))),
     };
-
-    let mock_cache = MockCacheProvider {
-      store_result: Arc::new(Mutex::new(Ok(()))),
-      store_calls: Arc::new(Mutex::new(Vec::new())),
-    };
+    let mock_cache = MockCacheProvider::new();
 
     let use_case = AuthenticationUseCase::new(mock_oauth, mock_cache);
 
@@ -390,14 +463,26 @@ mod tests {
         PkceCodeVerifier::new("test_verifier".to_string()),
       )))),
       received_scopes: Arc::new(Mutex::new(None)),
+      get_token_result: Arc::new(Mutex::new(Ok(OAuthTokenResponse {
+        access_token: "test_access_token".to_string(),
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        refresh_token: Some("test_refresh_token".to_string()),
+        scope: "openid profile".to_string(),
+      }))),
+      provider_config: Arc::new(Mutex::new(Ok(ProviderConfig {
+        authorization_endpoint: "https://auth.example.com/authorize".to_string(),
+        token_endpoint: "https://auth.example.com/token".to_string(),
+        revocation_endpoint: Some("https://auth.example.com/revoke".to_string()),
+        client_id: "test_client_id".to_string(),
+        redirect_uri: "https://app.example.com/callback".to_string(),
+        issuer: "https://auth.example.com".to_string(),
+      }))),
     };
 
-    let cache_error: Result<(), Box<dyn std::error::Error + Send + Sync>> = Err("Redis connection failed".into());
+    let mock_cache = MockCacheProvider::new();
 
-    let mock_cache = MockCacheProvider {
-      store_result: Arc::new(Mutex::new(cache_error)),
-      store_calls: Arc::new(Mutex::new(Vec::new())),
-    };
+    *mock_cache.store_result.lock().unwrap() = Err("Redis connection failed".into());
 
     let use_case = AuthenticationUseCase::new(mock_oauth, mock_cache);
 
@@ -418,6 +503,195 @@ mod tests {
       AuthError::ProviderError(msg) => {
         assert!(msg.contains("Failed to store PKCE session"));
         assert!(msg.contains("Redis connection failed"));
+      }
+      err => panic!("Expected ProviderError but got: {:?}", err),
+    }
+  }
+
+  #[tokio::test]
+  async fn test_handle_callback_success() {
+    let mock_oauth = MockOAuthProvider {
+      generate_auth_url_result: Arc::new(Mutex::new(Ok((
+        "https://auth.example.com/authorize".to_string(),
+        CsrfToken::new("test_state".to_string()),
+        PkceCodeVerifier::new("test_verifier".to_string()),
+      )))),
+      received_scopes: Arc::new(Mutex::new(None)),
+      get_token_result: Arc::new(Mutex::new(Ok(OAuthTokenResponse {
+        access_token: "test_access_token".to_string(),
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        refresh_token: Some("test_refresh_token".to_string()),
+        scope: "openid profile".to_string(),
+      }))),
+      provider_config: Arc::new(Mutex::new(Ok(ProviderConfig {
+        authorization_endpoint: "https://auth.example.com/authorize".to_string(),
+        token_endpoint: "https://auth.example.com/token".to_string(),
+        revocation_endpoint: Some("https://auth.example.com/revoke".to_string()),
+        client_id: "test_client_id".to_string(),
+        redirect_uri: "https://app.example.com/callback".to_string(),
+        issuer: "https://auth.example.com".to_string(),
+      }))),
+    };
+
+    let mock_cache = MockCacheProvider::new();
+    set_mock_time(TEST_TIMESTAMP);
+
+    let use_case = AuthenticationUseCase::new(mock_oauth, mock_cache);
+
+    let request = CallbackRequest {
+      code: "test_code".to_string(),
+      state: "test_state".to_string(),
+      code_verifier: "test_verifier".to_string(),
+    };
+
+    let result = use_case.handle_callback(request).await;
+    reset_mock_time();
+
+    assert!(result.is_ok(), "Expected success but got error: {:?}", result.err());
+
+    let token_response = result.unwrap();
+    assert_eq!(token_response.access_token, "test_access_token");
+    assert_eq!(token_response.token_type, "Bearer");
+    assert_eq!(token_response.expires_in, 3600);
+    assert_eq!(token_response.refresh_token, Some("test_refresh_token".to_string()));
+    assert_eq!(token_response.issuer, "https://auth.example.com");
+  }
+
+  #[tokio::test]
+  async fn test_handle_callback_invalid_state() {
+    let mock_oauth = MockOAuthProvider {
+      generate_auth_url_result: Arc::new(Mutex::new(Ok((
+        "https://auth.example.com/authorize".to_string(),
+        CsrfToken::new("test_state".to_string()),
+        PkceCodeVerifier::new("test_verifier".to_string()),
+      )))),
+      received_scopes: Arc::new(Mutex::new(None)),
+      get_token_result: Arc::new(Mutex::new(Ok(OAuthTokenResponse {
+        access_token: "test_access_token".to_string(),
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        refresh_token: Some("test_refresh_token".to_string()),
+        scope: "openid profile".to_string(),
+      }))),
+      provider_config: Arc::new(Mutex::new(Ok(ProviderConfig {
+        authorization_endpoint: "https://auth.example.com/authorize".to_string(),
+        token_endpoint: "https://auth.example.com/token".to_string(),
+        revocation_endpoint: Some("https://auth.example.com/revoke".to_string()),
+        client_id: "test_client_id".to_string(),
+        redirect_uri: "https://app.example.com/callback".to_string(),
+        issuer: "https://auth.example.com".to_string(),
+      }))),
+    };
+
+    let mock_cache = MockCacheProvider::new();
+
+    let use_case = AuthenticationUseCase::new(mock_oauth, mock_cache);
+
+    let request = CallbackRequest {
+      code: "test_code".to_string(),
+      state: "invalid_state".to_string(),
+      code_verifier: "test_verifier".to_string(),
+    };
+
+    let result = use_case.handle_callback(request).await;
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+      AuthError::InvalidState => {}
+      err => panic!("Expected InvalidState but got: {:?}", err),
+    }
+  }
+
+  #[tokio::test]
+  async fn test_handle_callback_session_expired() {
+    let mock_oauth = MockOAuthProvider {
+      generate_auth_url_result: Arc::new(Mutex::new(Ok((
+        "https://auth.example.com/authorize".to_string(),
+        CsrfToken::new("test_state".to_string()),
+        PkceCodeVerifier::new("test_verifier".to_string()),
+      )))),
+      received_scopes: Arc::new(Mutex::new(None)),
+      get_token_result: Arc::new(Mutex::new(Ok(OAuthTokenResponse {
+        access_token: "test_access_token".to_string(),
+        token_type: "Bearer".to_string(),
+        expires_in: 3600,
+        refresh_token: Some("test_refresh_token".to_string()),
+        scope: "openid profile".to_string(),
+      }))),
+      provider_config: Arc::new(Mutex::new(Ok(ProviderConfig {
+        authorization_endpoint: "https://auth.example.com/authorize".to_string(),
+        token_endpoint: "https://auth.example.com/token".to_string(),
+        revocation_endpoint: Some("https://auth.example.com/revoke".to_string()),
+        client_id: "test_client_id".to_string(),
+        redirect_uri: "https://app.example.com/callback".to_string(),
+        issuer: "https://auth.example.com".to_string(),
+      }))),
+    };
+
+    let mock_cache = MockCacheProvider::new();
+
+    let use_case = AuthenticationUseCase::new(mock_oauth, mock_cache);
+
+    set_mock_time(TEST_TIMESTAMP + AuthorizationConstants::PKCE_SESSION_TTL_SECONDS + 1);
+
+    let request = CallbackRequest {
+      code: "test_code".to_string(),
+      state: "test_state".to_string(),
+      code_verifier: "test_verifier".to_string(),
+    };
+
+    let result = use_case.handle_callback(request).await;
+
+    reset_mock_time();
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+      AuthError::SessionExpired => {}
+      err => panic!("Expected SessionExpired but got: {:?}", err),
+    }
+  }
+
+  #[tokio::test]
+  async fn test_handle_callback_token_error() {
+    let mock_oauth = MockOAuthProvider {
+      generate_auth_url_result: Arc::new(Mutex::new(Ok((
+        "https://auth.example.com/authorize".to_string(),
+        CsrfToken::new("test_state".to_string()),
+        PkceCodeVerifier::new("test_verifier".to_string()),
+      )))),
+      received_scopes: Arc::new(Mutex::new(None)),
+      get_token_result: Arc::new(Mutex::new(Err(AuthError::ProviderError(
+        "Failed to get token".to_string(),
+      )))),
+      provider_config: Arc::new(Mutex::new(Ok(ProviderConfig {
+        authorization_endpoint: "https://auth.example.com/authorize".to_string(),
+        token_endpoint: "https://auth.example.com/token".to_string(),
+        revocation_endpoint: Some("https://auth.example.com/revoke".to_string()),
+        client_id: "test_client_id".to_string(),
+        redirect_uri: "https://app.example.com/callback".to_string(),
+        issuer: "https://auth.example.com".to_string(),
+      }))),
+    };
+
+    let mock_cache = MockCacheProvider::new();
+    let use_case = AuthenticationUseCase::new(mock_oauth, mock_cache);
+
+    let request = CallbackRequest {
+      code: "test_code".to_string(),
+      state: "test_state".to_string(),
+      code_verifier: "test_verifier".to_string(),
+    };
+    set_mock_time(TEST_TIMESTAMP);
+
+    let result = use_case.handle_callback(request).await;
+
+    reset_mock_time();
+
+    assert!(result.is_err());
+    match result.unwrap_err() {
+      AuthError::ProviderError(msg) => {
+        assert_eq!(msg, "Failed to get token");
       }
       err => panic!("Expected ProviderError but got: {:?}", err),
     }

--- a/src/core/usecase/authentication.rs
+++ b/src/core/usecase/authentication.rs
@@ -1,16 +1,34 @@
 use crate::{
   core::domain::auth::{constants::AuthorizationConstants, error::AuthError},
   port::{
-    inbound::authentication::{AuthenticationPort, RedirectUrlRequest, RedirectUrlResponse},
-    outbound::{cache_provider::CacheProvider, oauth_provider::OAuthProvider},
+    inbound::authentication::{
+      AuthenticationPort, CallbackRequest, RedirectUrlRequest, RedirectUrlResponse, TokenResponse,
+    },
+    outbound::{
+      cache_provider::CacheProvider,
+      oauth_provider::{GrantType, OAuthProvider, TokenRequest},
+    },
   },
 };
 use async_trait::async_trait;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use super::utils::time_utils::now_time_secs;
 
-#[derive(Serialize)]
+impl From<Box<dyn std::error::Error>> for AuthError {
+  fn from(error: Box<dyn std::error::Error>) -> Self {
+    AuthError::ProviderError(error.to_string())
+  }
+}
+
+impl From<Box<dyn std::error::Error + Send + Sync>> for AuthError {
+  fn from(error: Box<dyn std::error::Error + Send + Sync>) -> Self {
+    AuthError::ProviderError(error.to_string())
+  }
+}
+
+#[derive(Serialize, Deserialize)]
 struct PkceSession {
   code_verifier: String,
   expires_at: u64,
@@ -66,28 +84,42 @@ impl<T: OAuthProvider + Clone + Send + Sync, C: CacheProvider + Clone + Send + S
     })
   }
 
-  // async fn handle_callback(&self, request: CallbackRequest) -> Result<TokenResponse, AuthError> {
-  //   let provider_config = self.oauth_provider.get_provider_config().await?;
+  async fn handle_callback(&self, request: CallbackRequest) -> Result<TokenResponse, AuthError> {
+    // 1. Retrieve the PKCE session from the cache
+    let session_key = AuthorizationConstants::pkce_session_key(&request.state);
+    let pkce_session: PkceSession = self.cache_provider.get(&session_key).await?.ok_or(AuthError::InvalidState)?;
 
-  //   let token_request = TokenRequest {
-  //     code: request.code,
-  //     code_verifier: request.code_verifier,
-  //     grant_type: GrantType::AuthorizationCode,
-  //     redirect_uri: provider_config.authorization_endpoint,
-  //     client_id: "".to_string(), // This should come from configuration
-  //   };
+    // 2. verify the session expiration
+    let now = now_time_secs().map_err(|err| AuthError::UnexpectedError(err.to_string()))?;
+    if now > pkce_session.expires_at {
+      return Err(AuthError::SessionExpired);
+    }
 
-  //   let token_response = self.oauth_provider.get_token(token_request).await?;
+    // 3. Delete the PKCE session from the cache
+    let _ = self.cache_provider.remove(&session_key).await;
 
-  //   Ok(TokenResponse {
-  //     access_token: token_response.access_token,
-  //     refresh_token: token_response.refresh_token,
-  //     token_type: token_response.token_type,
-  //     expires_in: token_response.expires_in,
-  //     issued_at: chrono::Utc::now().to_rfc3339(),
-  //     issuer: provider_config.token_endpoint,
-  //   })
-  // }
+    // 3. fetch provider config
+    let provider_config = self.oauth_provider.get_provider_config().await?;
+
+    let token_request = TokenRequest {
+      code: request.code,
+      grant_type: GrantType::AuthorizationCode,
+      client_id: provider_config.client_id,
+      redirect_uri: provider_config.redirect_uri,
+      code_verifier: pkce_session.code_verifier,
+    };
+
+    let token_response = self.oauth_provider.get_token(token_request).await?;
+
+    Ok(TokenResponse {
+      access_token: token_response.access_token,
+      refresh_token: token_response.refresh_token,
+      token_type: token_response.token_type,
+      expires_in: token_response.expires_in,
+      issued_at: SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs().to_string(),
+      issuer: provider_config.issuer,
+    })
+  }
 
   // async fn verify_token(&self, token: String) -> Result<TokenVerificationResponse, AuthError> {
   //   // In a real implementation, this would verify the token with the OAuth provider

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ async fn main() {
     &config.oauth.client_id,
     Some(&config.oauth.client_secret),
     &config.oauth.redirect_url,
+    &config.oauth.issuer,
   )
   .expect("Failed to initialize OAuth provider");
 

--- a/src/port/inbound/authentication.rs
+++ b/src/port/inbound/authentication.rs
@@ -49,7 +49,7 @@ pub trait AuthenticationPort {
   async fn generate_redirect_uri(&self, request: RedirectUrlRequest) -> Result<RedirectUrlResponse, AuthError>;
 
   // /// Handle OAuth callback
-  // async fn handle_callback(&self, request: CallbackRequest) -> Result<TokenResponse, AuthError>;
+  async fn handle_callback(&self, request: CallbackRequest) -> Result<TokenResponse, AuthError>;
 
   // /// Verify access token
   // async fn verify_token(&self, token: String) -> Result<TokenVerificationResponse, AuthError>;

--- a/src/port/outbound/oauth_provider.rs
+++ b/src/port/outbound/oauth_provider.rs
@@ -60,4 +60,7 @@ pub struct ProviderConfig {
   pub authorization_endpoint: String,
   pub token_endpoint: String,
   pub revocation_endpoint: Option<String>,
+  pub client_id: String,
+  pub redirect_uri: String,
+  pub issuer: String,
 }

--- a/tests/integrations/authentication_test.rs
+++ b/tests/integrations/authentication_test.rs
@@ -258,6 +258,7 @@ async fn create_oauth_provider_with_retry(oauth_url: &str) -> Result<OkkaOAuthPr
       "test-client-id",
       Some("test-client-secret"),
       "http://localhost:3000/callback",
+      "test-issuer",
     ) {
       Ok(provider) => {
         println!("OAuth provider created successfully on attempt {}", attempt);


### PR DESCRIPTION
## Sourceryによるサマリー

このプルリクエストは、認証ユースケースにおけるOAuthコールバック処理ロジックを実装します。また、ユニットテストを追加し、CIワークフローをリファクタリングします。

新機能:
- `AuthenticationUseCase`に`handle_callback`関数を実装し、OAuthコールバックを処理し、PKCEセッションを検証し、OAuthプロバイダーからアクセストークンを取得します。

機能拡張:
- `AuthError`に`From`トレイトを実装して、外部クレートからのエラーを変換することにより、エラー処理をリファクタリングします。
- `ProviderConfig`構造体を更新して、`client_id`、`redirect_uri`、および`issuer`フィールドを含めます。
- `OkkaOAuthProvider`を更新して、issuerを保存し、`ProviderConfig`に含めます。
- CIワークフローを更新して、linting、ユニットテスト、および統合テストのための個別のジョブを含めます。

テスト:
- `handle_callback`関数のユニットテストを追加して、正常なパスと、無効な状態、期限切れのセッション、トークン取得の失敗などのエラーケースを検証します。
- OAuthプロバイダーとキャッシュプロバイダーのモック実装を追加して、テストを容易にします。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request implements the OAuth callback handling logic in the authentication use case. It also adds unit tests and refactors the CI workflow.

New Features:
- Implements the `handle_callback` function in the `AuthenticationUseCase` to process the OAuth callback, verify the PKCE session, and retrieve the access token from the OAuth provider.

Enhancements:
- Refactors error handling by implementing `From` trait for `AuthError` to convert errors from external crates.
- Updates the `ProviderConfig` struct to include `client_id`, `redirect_uri`, and `issuer` fields.
- Updates the `OkkaOAuthProvider` to store the issuer and include it in the `ProviderConfig`.
- Updates the CI workflow to include separate jobs for linting, unit tests, and integration tests.

Tests:
- Adds unit tests for the `handle_callback` function to verify the happy path and error cases such as invalid state, expired session, and token retrieval failure.
- Adds mock implementations for OAuth provider and cache provider to facilitate testing.

</details>